### PR TITLE
Update tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch = True
 omit = setup.py, */migrations/*, */conftest.py
 
 [report]
+show_missing = true
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 /build
 /dist
 /docs/_build
+/.htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,34 @@ language: python
 
 sudo: false
 
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5
+
 env:
   matrix:
+    - TOXENV=py27-dj14
     - TOXENV=py27-dj15
     - TOXENV=py27-dj16
     - TOXENV=py27-dj17
     - TOXENV=py27-dj18
+    - TOXENV=py27-dj19
     - TOXENV=py34-dj15
     - TOXENV=py34-dj16
     - TOXENV=py34-dj17
     - TOXENV=py34-dj18
-    - TOXENV=pypy19-dj15
-    - TOXENV=pypy19-dj16
-    - TOXENV=pypy19-dj17
-    - TOXENV=pypy19-dj18
-    - TOXENV=py27-dj14
-    - TOXENV=pypy19-dj14
+    - TOXENV=py34-dj19
+    - TOXENV=py35-dj18
+    - TOXENV=py35-dj19
+    - TOXENV=pypy-dj14
+    - TOXENV=pypy-dj15
+    - TOXENV=pypy-dj16
+    - TOXENV=pypy-dj17
+    - TOXENV=pypy-dj18
+    - TOXENV=pypy-dj19
     - TOXENV=flake8
 
 cache:

--- a/djclick/params.py
+++ b/djclick/params.py
@@ -19,5 +19,8 @@ class ModelInstance(click.ParamType):
         try:
             return self.qs.get(pk=value)
         except ObjectDoesNotExist:
-            msg = 'could not find {} with pk={}'.format(self.name, value)
-            self.fail(msg, param, ctx)
+            pass
+        # call `fail` outside of exception context to avoid nested exception
+        # handling on Python 3
+        msg = 'could not find {} with pk={}'.format(self.name, value)
+        self.fail(msg, param, ctx)

--- a/djclick/test/test_adapter.py
+++ b/djclick/test/test_adapter.py
@@ -145,8 +145,8 @@ def test_django_traceback(manage):
         assert lines[0] == b'Traceback (most recent call last):'
         for line in lines[1:-1]:
             assert line.startswith(b'  ')
-        assert lines[-1] == (b'django.core.management.base.CommandError: '
-                             b'Raised error description')
+        # Use `.endswith()` because of differences between CPython and pypy
+        assert lines[-1].endswith(b'CommandError: Raised error description')
         assert e.returncode == 1
     else:
         assert False  # NOCOV

--- a/djclick/test/test_params.py
+++ b/djclick/test/test_params.py
@@ -1,12 +1,11 @@
-import os
-import subprocess
+import pytest
+from click.exceptions import BadParameter
 
 from djclick import params
 
 
+@pytest.mark.django_db
 def test_modelinstance_init():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'testprj.settings')
-
     from testapp.models import DummyModel
     from django.db.models.query import QuerySet
 
@@ -18,21 +17,18 @@ def test_modelinstance_init():
     assert param.qs is qs
 
 
-def test_convert_ok(manage):
-    assert manage('modelcmd', 'MODEL') == b'MODEL'
+@pytest.mark.django_db
+def test_convert_ok(call_command):
+    from testapp.models import DummyModel
+
+    DummyModel.objects.create()
+    assert call_command('modelcmd', '1').stdout == b'1'
 
 
-def test_convert_fail(manage):
-    try:
-        manage('modelcmd', 'ND')
-    except subprocess.CalledProcessError as e:
-        lines = e.output.strip().splitlines()
-        assert b'Traceback (most recent call last):' == lines[0]
-        for line in lines[1:-1]:
-            assert line.startswith(b'  ')
-        # Use `.endswith()` because of differences between CPython and pypy
-        assert lines[-1].endswith(b'BadParameter: could not find '
-                                  b'testapp.DummyModel with pk=ND')
-        assert e.returncode == 1
-    else:
-        assert False  # NOCOV
+@pytest.mark.django_db
+def test_convert_fail(call_command):
+    with pytest.raises(BadParameter) as e:
+        call_command('modelcmd', '999')
+    # Use `.endswith()` because of differences between CPython and pypy
+    assert str(e).endswith('BadParameter: could not find '
+                           'testapp.DummyModel with pk=999')

--- a/djclick/test/test_params.py
+++ b/djclick/test/test_params.py
@@ -27,11 +27,12 @@ def test_convert_fail(manage):
         manage('modelcmd', 'ND')
     except subprocess.CalledProcessError as e:
         lines = e.output.strip().splitlines()
-        assert lines[0] == b'Traceback (most recent call last):'
+        assert b'Traceback (most recent call last):' == lines[0]
         for line in lines[1:-1]:
             assert line.startswith(b'  ')
-        assert lines[-1] == (b'click.exceptions.BadParameter: '
-                             b'could not find testapp.DummyModel with pk=ND')
+        # Use `.endswith()` because of differences between CPython and pypy
+        assert lines[-1].endswith(b'BadParameter: could not find '
+                                  b'testapp.DummyModel with pk=ND')
         assert e.returncode == 1
     else:
         assert False  # NOCOV

--- a/djclick/test/testprj/testapp/management/commands/modelcmd.py
+++ b/djclick/test/testprj/testapp/management/commands/modelcmd.py
@@ -1,26 +1,11 @@
-from django.core.exceptions import ObjectDoesNotExist
-
 import djclick as click
 from djclick.params import ModelInstance
 
 from testapp.models import DummyModel
 
 
-class DummyQuerySet(object):
-    model = DummyModel
-
-    def __init__(self, pk):
-        self.pk = pk
-
-    def get(self, pk):
-        if pk == self.pk:
-            return pk
-        else:
-            raise ObjectDoesNotExist()
-
-
 @click.command()
-@click.argument('instance', type=ModelInstance(DummyQuerySet('MODEL')))
+@click.argument('instance', type=ModelInstance(DummyModel.objects.all()))
 def command(instance):
     # Just print some things which shall not be found in the output
     click.echo(instance, nl=False)

--- a/djclick/test/testprj/testapp/models.py
+++ b/djclick/test/testprj/testapp/models.py
@@ -1,5 +1,10 @@
+from __future__ import unicode_literals
+
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class DummyModel(models.Model):
-    pass
+    def __str__(self):
+        return str(self.id)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
 pytest
+pytest-django
 pytest-cov
 pytest-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,18 @@
 toxworkdir = {homedir}/.toxenvs/django-click
 envlist =
     coverage_erase,
-    {py27,py34,pypy19}-{dj15,dj16,dj17,dj18},
-    {py27,pypy19}-dj14,
+    py{27,py}-dj14,
+    py{27,34,py}-dj{15,16,17,18,19},
+    py35-dj{18,19},
     flake8,
     coverage_report
 
 [testenv]
 usedevelop = true
 passenv = LC_ALL, LANG, LC_CTYPE
+setenv =
+    DJANGO_SETTINGS_MODULE=testprj.settings
+    PYTHONPATH={toxinidir}/djclick/test/testprj
 deps =
     -rrequirements-test.txt
     dj14: django>=1.4,<1.5
@@ -20,7 +24,8 @@ deps =
     dj16: django>=1.6,<1.7
     dj17: django>=1.7,<1.8
     dj18: django>=1.8,<1.9
-commands = py.test -rxs --cov-report= --cov-append --cov djclick djclick
+    dj19: django>=1.9,<1.10
+commands = py.test -rxs --cov-report= --cov-append --cov djclick {posargs:djclick}
 
 [testenv:coverage_erase]
 commands = coverage erase
@@ -31,5 +36,7 @@ commands = flake8 djclick
 deps = flake8
 
 [testenv:coverage_report]
-commands = coverage html
+commands =
+  coverage report
+  coverage html
 deps = coverage


### PR DESCRIPTION
Various test updates. In detail:

- Test on Python 3.5 and Django 1.9
- Rename `pypy19` tox env to `pypy` since `pypy19` is not recognized by tox as pypy and caused the tests to run on cpython 2.7 instead
- Fixes some failing Python 3 tests 
- Add coverage terminal reporting output
- Add pytest-django. This allows to use real models in `test_params` instead of the `DummyQuerySet`