### PR TITLE
Fix issues with recent versions of click and django

### DIFF
--- a/djclick/adapter.py
+++ b/djclick/adapter.py
@@ -60,7 +60,10 @@ class DjangoCommandMixin(object):
         Called when run from the command line.
         """
         try:
-            return self.main(args=argv[2:], standalone_mode=False)
+            # We won't get an exception here in standalone_mode=False
+            exit_code = self.main(args=argv[2:], standalone_mode=False)
+            if exit_code:
+                sys.exit(exit_code)
         except click.ClickException as e:
             if getattr(e.ctx, 'traceback', False):
                 raise

--- a/djclick/adapter.py
+++ b/djclick/adapter.py
@@ -65,7 +65,7 @@ class DjangoCommandMixin(object):
             if exit_code:
                 sys.exit(exit_code)
         except click.ClickException as e:
-            if getattr(e.ctx, 'traceback', False):
+            if hasattr(e, 'ctx') and getattr(e.ctx, 'traceback', False):
                 raise
             e.show()
             sys.exit(e.exit_code)

--- a/djclick/adapter.py
+++ b/djclick/adapter.py
@@ -27,6 +27,7 @@ class ArgumentParserDefaults(object):
 class ArgumentParserAdapter(object):
     def __init__(self):
         self._actions = []
+        self._mutually_exclusive_groups = []
 
     def parse_args(self, args):
         return ArgumentParserDefaults(args)

--- a/djclick/adapter.py
+++ b/djclick/adapter.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from functools import update_wrapper
 
@@ -59,9 +60,10 @@ class DjangoCommandMixin(object):
         """
         Called when run from the command line.
         """
+        prog_name = '{} {}'.format(os.path.basename(argv[0]), argv[1])
         try:
             # We won't get an exception here in standalone_mode=False
-            exit_code = self.main(args=argv[2:], standalone_mode=False)
+            exit_code = self.main(args=argv[2:], prog_name=prog_name, standalone_mode=False)
             if exit_code:
                 sys.exit(exit_code)
         except click.ClickException as e:
@@ -80,16 +82,13 @@ class DjangoCommandMixin(object):
             return OptionParseAdapter()
 
     def print_help(self, prog_name, subcommand):
-        self.main(['--help'], standalone_mode=False)
+        prog_name = '{} {}'.format(prog_name, subcommand)
+        self.main(['--help'], prog_name=prog_name, standalone_mode=False)
 
     def map_names(self):
         for param in self.params:
             for opt in param.opts:
                 yield opt.lstrip('--').replace('-', '_'), param.name
-
-    def collect_usage_pieces(self, ctx):
-        pieces = super(DjangoCommandMixin, self).collect_usage_pieces(ctx)
-        return [self.name] + pieces
 
     def execute(self, *args, **kwargs):
         """
@@ -200,7 +199,6 @@ class BaseRegistrator(object):
     def get_params(self, name):
         def show_help(ctx, param, value):
             if value and not ctx.resilient_parsing:
-                ctx.info_name += ' ' + name
                 click.echo(ctx.get_help(), color=ctx.color)
                 ctx.exit()
 

--- a/djclick/adapter.py
+++ b/djclick/adapter.py
@@ -53,7 +53,8 @@ class DjangoCommandMixin(object):
             # Honor the --traceback flag
             if ctx.traceback:
                 raise
-            click.echo('{}: {}'.format(e.__class__.__name__, e), err=True)
+            styled_message = click.style('{}: {}'.format(e.__class__.__name__, e), fg='red', bold=True)
+            click.echo(styled_message, err=True)
             ctx.exit(1)
 
     def run_from_argv(self, argv):

--- a/djclick/test/test_adapter.py
+++ b/djclick/test/test_adapter.py
@@ -70,10 +70,10 @@ def test_call_command_required_args():
 
 def test_call_command_required_args_cli(manage):
     out = manage('requiredargcmd', ignore_errors=True)
-    assert out == (
-        b'Usage: manage.py requiredargcmd [OPTIONS] ARG\n'
+    assert out.lower() == (
+        b'usage: manage.py requiredargcmd [options] arg\n'
         b'\n'
-        b'Error: Missing argument "arg".\n'
+        b'error: missing argument "arg".\n'
     )
 
 

--- a/djclick/test/test_adapter.py
+++ b/djclick/test/test_adapter.py
@@ -219,6 +219,17 @@ def test_django_help(manage):
     assert help_text.startswith(b'Usage: manage.py helpcmd ')
 
 
+def test_command_name_in_help(manage):
+    # Doesn't matter which name, as long as we know it.
+    out = manage('helpcmd', '-h')
+    assert b'manage.py helpcmd [OPTIONS]' in out
+
+
+def test_command_names_in_subcommand_help(manage):
+    out = manage('groupcmd', 'subcmd1', '-h')
+    assert b'manage.py groupcmd subcmd1' in out
+
+
 def test_django_version(manage):
     django_version = django.get_version().encode('ascii') + b'\n'
     assert manage('testcmd', '--version') == django_version

--- a/djclick/test/test_params.py
+++ b/djclick/test/test_params.py
@@ -46,7 +46,5 @@ def test_convert_ok(call_command, arg, value):
 def test_convert_fail(call_command, args, error_message):
     with pytest.raises(BadParameter) as e:
         call_command('modelcmd', *args)
-    # Use `.endswith()` because of differences between CPython and pypy
-    assert str(e).endswith(
-        'BadParameter: could not find testapp.DummyModel with {}'.format(
-            error_message))
+    assert e.match(
+        'could not find testapp.DummyModel with {}'.format(error_message))

--- a/djclick/test/testprj/testapp/models.py
+++ b/djclick/test/testprj/testapp/models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Fix multiple issues with recent versions of click and Django:

* Django 3 removes Python 2 compatibility shims, like `python_2_unicode_compatible`; use the one from `six` instead
* Django 3 handles `ArgumentParser`'s mutually exclusive groups; add the attribute to `ArgumentParserAdapt` to make Django happy 
* Recent versions of `click` do not exit on `ctx.exit()` if `standalone_mode = False`, instead returning the exit code from `Command.main()`; use that exit code and exit "manually" instead, if it's non-zero
* Different versions of `click` cases metavars differently; lowercase some output in tests to make checking equality more compatible with multiple `click` versions
* Different versions of `pytest` stringifies `ExceptionInfo` differently; match against exception message in tests instead of checking against how `pytest` formats its wrapper
* Fix help and usage output to show command names correctly; specifically, don't show the base command name twice, and show it (once) when showing usage for sub-commands (Fixes #8)
* Style `CommandError` like Django, with red, bold text