### PR TITLE
Update CI to test against supported Django/Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
-          - "pypy-3.6"
-          - "pypy-3.7"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "pypy-3.9"
+          - "pypy-3.10"
         tox-env:
-          - "dj22" # LTS
-          - "dj31"
-          - "dj32" # LTS
+          - "dj42" # LTS
+          - "dj50"
         exclude:
-          # Python 3.9 is compatible with Django 3.1+
+          # Python 3.8/3.9 is incompatible with Django 5.0+
+          - python-version: "3.8"
+            tox-env: "dj50"
           - python-version: "3.9"
-            tox-env: "dj22"
-          - python-version: "3.9"
-            tox-env: "dj30"
+            tox-env: "dj50"
+          - python-version: "pypy-3.9"
+            tox-env: "dj50"
 
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.12'
 
     - name: Install tox and flake8 packages
       run: pip install tox tox-gh-actions flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "pypy-3.9"
-          - "pypy-3.10"
         tox-env:
           - "dj42" # LTS
           - "dj50"
@@ -28,8 +26,6 @@ jobs:
           - python-version: "3.8"
             tox-env: "dj50"
           - python-version: "3.9"
-            tox-env: "dj50"
-          - python-version: "pypy-3.9"
             tox-env: "dj50"
 
     env:

--- a/README.rst
+++ b/README.rst
@@ -27,15 +27,12 @@ Automated code metrics:
 .. image:: https://img.shields.io/codeclimate/github/GaretJax/django-click.svg
    :target: https://codeclimate.com/github/GaretJax/django-click
 
-.. image:: https://img.shields.io/requires/github/GaretJax/django-click.svg
-   :target: https://requires.io/github/GaretJax/django-click/requirements/?branch=master
-
 ``django-click`` is a library to easily write Django management commands using the
 ``click`` command line library.
 
 * Free software: MIT license
 * Documentation for the Click command line library: https://click.palletsprojects.com/en/8.0.x/
-* Compatible with Django 2.2, 3.1, or 3.2 running on Python 3.6, 3.7, 3.8, 3.9, and PyPy.
+* Compatible with Django 4.2 and 5.0 running on Python 3.8, 3.9, 3.10, 3.11, and 3.12 (note: 3.10+ required for Django 5.0).
 
 
 Installation

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,4 @@
 [tox]
-# Having the .tox directory in the project directory slows down the
-# `pip install -e .` step required by `usedevelop = true` considerably.
-# By moving it out of the way (~500MB), we trim test execution time by > 80%.
-toxworkdir = {homedir}/.toxenvs/django-click
 envlist =
     dj{42,50},flake8
 
@@ -12,7 +8,7 @@ django =
     5.0: dj50
 
 [testenv]
-usedevelop = true
+package = editable
 passenv = LC_ALL, LANG, LC_CTYPE
 setenv =
     DJANGO_SETTINGS_MODULE=testprj.settings

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,12 @@
 # By moving it out of the way (~500MB), we trim test execution time by > 80%.
 toxworkdir = {homedir}/.toxenvs/django-click
 envlist =
-    dj{22,31,32},flake8
+    dj{42,50},flake8
 
 [gh-actions]
 django =
-    2.2: dj22
-    3.1: dj31
-    3.2: dj32
+    4.2: dj42
+    5.0: dj50
 
 [testenv]
 usedevelop = true
@@ -20,9 +19,8 @@ setenv =
     PYTHONPATH={toxinidir}/djclick/test/testprj
 deps =
     -rrequirements-test.txt
-    dj22: django>=2.2,<2.3
-    dj31: django>=3.1,<3.2
-    dj32: django>=3.2,<3.3
+    dj42: django>=4.2,<4.3
+    dj50: django>=5.0,<5.1
 commands = py.test -rxs --cov-report= --cov-append --cov djclick {posargs:djclick}
 
 


### PR DESCRIPTION
## Changes

- Drops support for Python 3.6 and 3.7 [which are end-of-life](https://devguide.python.org/versions/).
- Drops support for Django < 4.2 [which are end-of-life.](https://endoflife.date/django)
- Drops support for PyPy which don't appear to be compatible with modern Django's type annotations (see [this](https://github.com/BrightpathProgress/django-click/actions/runs/8734153985/job/23964221040) failed run)
- Adds support for Python 3.10, 3.11, and 3.12
- Adds support for Django 4.2 and 5.0
- Updates the linting CI task to run on the most recent Python (as Python 3.6 is no longer available on GitHub actions)
- Updates the tox config so that it works with the latest tox. This required removing the patch for moving the tox working directory to the home directory, as the `{homedir}` substitution was removed without replacement in tox v4. However, the new `package=editable` option appears to perform an editable install without copying any files at all, which should negate the original reason for moving the tox directories in the first place. `package=editable` is also now recommended over `usedevelop=true` in the tox documentation.
- Removes the requires.io badge as the domain is now for sale.

Passing test run can be found [here](https://github.com/BrightpathProgress/django-click/actions/runs/8734278697).