### PR TITLE
Sync trove classifiers (Python versions) to tested versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 


### PR DESCRIPTION
* Removes 3.6 and 3.7
* Adds 3.10, 3.11 and 3.12

The PyPI page of the package was giving the impression that package wasn't updated for a while

![CleanShot 2024-07-31 at 13 17 11@2x](https://github.com/user-attachments/assets/33589e29-a2ab-4d35-9cc8-75ed2145fee0)
